### PR TITLE
Fix supabase client import error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { Plus, Truck, RefreshCw, FileText, AlertCircle, Wifi, Menu, X, Calendar,
 import Pengiriman from './components/Pengiriman';
 import { BrowserRouter as Router, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
-import { supabase } from './lib/supabaseClient';
+import { supabase } from './lib/supabase';
 
 function App() {
   const { notes, loading, error, createNote, updateNote, removeNote, getStats, refreshNotes } = useDeliveryNotes();


### PR DESCRIPTION
Corrects `supabase` import path to resolve build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-44d8e8cb-eea9-40b7-8494-50bce24bff94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44d8e8cb-eea9-40b7-8494-50bce24bff94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

